### PR TITLE
fixing bug where `start` was getting overriden if buffer-remaining is > 0

### DIFF
--- a/src/io.lisp
+++ b/src/io.lisp
@@ -129,13 +129,13 @@
             (incf (output-buffer-fill output-buffer)
                   (min buffer-remaining len)))
           (when (< start2 len)
-            (extend output-buffer (- len start2))
-            (replace (output-buffer-vector output-buffer)
-                     (the octet-vector sequence)
-                     :start2 start2
-                     :end2 end)
-            (incf (output-buffer-fill output-buffer)
-                  (- len start2)))
+            (let ((num-bytes (- (or end (length sequence)) start2)))
+              (extend output-buffer num-bytes)
+              (replace (output-buffer-vector output-buffer)
+                       (the octet-vector sequence)
+                       :start2 start2
+                       :end2 end)
+              (incf (output-buffer-fill output-buffer) num-bytes)))
           (incf (output-buffer-len output-buffer) len)
           len))))
 


### PR DESCRIPTION
This was causing some data corruption in an HTTP client I'm writing. I think this should fix it!
