### PR TITLE
Omit STREAM for fast-input-stream w/LW

### DIFF
--- a/src/gray.lisp
+++ b/src/gray.lisp
@@ -27,7 +27,7 @@
 
  ;; fast-input-stream
 
-(defclass fast-input-stream (stream trivial-gray-stream-mixin)
+(defclass fast-input-stream (#-lispworks stream trivial-gray-stream-mixin)
   ((buffer :type input-buffer)))
 
 (defmethod initialize-instance ((self fast-input-stream) &key stream


### PR DESCRIPTION
Commit 5f330b97c7189ddf44ae81a14a344ec3654c26dd lets fast-output-stream 
inherit from stream when not on LispWorks.  Let's do the same for 
fast-input-stream to avoid the error messages such as this one:

#<BUILT-IN-CLASS STREAM 41605693E3> is an invalid superclass of 
#<STANDARD-CLASS FAST-INPUT-STREAM 4020239F13>.