### PR TITLE
CLISP doesn't allow standard classes to inherit stream.

### DIFF
--- a/src/gray.lisp
+++ b/src/gray.lisp
@@ -2,7 +2,7 @@
 
  ;; fast-output-stream
 
-(defclass fast-output-stream (#-lispworks stream
+(defclass fast-output-stream (#-(or lispworks clisp) stream
                               trivial-gray-stream-mixin)
   ((buffer :type output-buffer)))
 
@@ -31,7 +31,7 @@
 
  ;; fast-input-stream
 
-(defclass fast-input-stream (#-lispworks stream trivial-gray-stream-mixin)
+(defclass fast-input-stream (#-(or lispworks clisp) stream trivial-gray-stream-mixin)
   ((buffer :type input-buffer)))
 
 (defmethod initialize-instance ((self fast-input-stream) &key stream


### PR DESCRIPTION
When loading `:fast-io` with GNU CLISP 2.49, it raises and error like this:

```
[1]> (ql:quickload :fast-io)
To load "fast-io":
  Load 1 ASDF system:
    fast-io
; Loading "fast-io"

*** - (INITIALIZE-INSTANCE CLASS) for class FAST-OUTPUT-STREAM: CLOS:VALIDATE-SUPERCLASS does not allow #<STANDARD-CLASS FAST-OUTPUT-STREAM :UNINITIALIZED> to become a subclass of #<BUILT-IN-CLASS STREAM>. You may define a method on
      CLOS:VALIDATE-SUPERCLASS to allow this.
The following restarts are available:
RETRY          :R1      Retry compiling #<CL-SOURCE-FILE "fast-io" "gray">.
ACCEPT         :R2      Continue, treating compiling #<CL-SOURCE-FILE "fast-io" "gray"> as having been successful.
ABORT          :R3      Give up on "fast-io"
ABORT          :R4      Abort main loop
Break 1 FAST-IO[2]>
```

It doesn't allow standard classes to inherit stream like LispWorks.