### PR TITLE
Use fundamental-X-stream instead of trivial-gray-stream-mixin

### DIFF
--- a/src/gray.lisp
+++ b/src/gray.lisp
@@ -2,8 +2,7 @@
 
  ;; fast-output-stream
 
-(defclass fast-output-stream (#-(or lispworks clisp) stream
-                              trivial-gray-stream-mixin)
+(defclass fast-output-stream (fundamental-output-stream)
   ((buffer :type output-buffer)))
 
 (defmethod initialize-instance ((self fast-output-stream) &key stream
@@ -31,7 +30,7 @@
 
  ;; fast-input-stream
 
-(defclass fast-input-stream (#-(or lispworks clisp) stream trivial-gray-stream-mixin)
+(defclass fast-input-stream (fundamental-input-stream)
   ((buffer :type input-buffer)))
 
 (defmethod initialize-instance ((self fast-input-stream) &key stream


### PR DESCRIPTION
This changes the superclasses of `fast-input-stream` and `fast-output-stream` from
`stream` and `trivial-gray-stream-mixin`, to just a single superclass for each,
`fundamental-input-stream` and `fundamental-output-stream`, respectively.

`trivial-gray-stream-mixin` is deprecated, and it appears all functionality has been transfered to `fundmental-input-stream` and `fundamental-output-stream`:
https://github.com/trivial-gray-streams/trivial-gray-streams/commit/99f579bd352156ad6dadcf347696a0a34a9e0f82