### PR TITLE
Flush to stream in finish-output-buffer

### DIFF
--- a/src/io.lisp
+++ b/src/io.lisp
@@ -163,7 +163,12 @@
     start1))
 
 (defun finish-output-buffer (output-buffer)
-  (concat-buffer output-buffer))
+  "Finish an output buffer. If it is backed by a vector (static or otherwise)
+it returns the final octet vector. If it is backed by a stream it ensures that
+all data has been flushed to the stream."
+  (if (streamp (output-buffer-output output-buffer))
+      (flush output-buffer)
+      (concat-buffer output-buffer)))
 
 (defmacro with-fast-output ((buffer &optional output) &body body)
   "Create `BUFFER`, optionally outputting to `OUTPUT`."


### PR DESCRIPTION
Flush to  the stream when finish-output-buffer is called on an output
buffer backed by a stream.

Previously any byte remaining in the buffer were never flushed, and
there was no public function to flush them to the stream.