### PR TITLE
Add INPUT-BUFFER and OUTPUT-BUFFER to exports

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -3,6 +3,7 @@
   (:export #:*default-output-buffer-size*
 
            #:octet #:octet-vector #:index
+           #:input-buffer #:output-buffer
 
            #:make-octet-vector #:octets-from
 


### PR DESCRIPTION
The symbols `INPUT-BUFFER` and `OUTPUT-BUFFER` should be exported as they are class names for objects created with exported symbols `MAKE-INPUT-BUFFER` and `MAKE-OUTPUT-BUFFER`. Client code is unable to use type declarations, type checks or write methods dispatching on these classes if these names are not exported.