### PR TITLE
Add SETF BUFFER-POSITION

### DIFF
--- a/src/io.lisp
+++ b/src/io.lisp
@@ -21,10 +21,16 @@
 
 (defun buffer-position (buffer)
   "Return the number of bytes read (for an INPUT-BUFFER) or written
-(for an OUTPUT-BUFFER)"
+\(for an OUTPUT-BUFFER)"
   (etypecase buffer
     (input-buffer (input-buffer-pos buffer))
     (output-buffer (output-buffer-len buffer))))
+
+(defun (setf buffer-position) (new-value buffer)
+  "Set the current position inside an INPUT-BUFFER."
+  (etypecase buffer
+    (input-buffer (setf (input-buffer-pos buffer) new-value))
+    (output-buffer (error "Unable to set position for OUTPUT-BUFFER."))))
 
 (declaim (ftype (function (index) octet-vector) make-octet-vector)
          (inline make-octet-vector))


### PR DESCRIPTION
The standard function `FILE-POSITION` allows to arbitrarily set the file position inside input file streams. The same should be possible for input buffers, so I can jump around various positions inside a buffer instead of creating new buffers whenever I want to go to a specific position.