### PR TITLE
add FAST-PEEK-BYTE.

### DIFF
--- a/src/io.lisp
+++ b/src/io.lisp
@@ -105,6 +105,20 @@
       (error 'end-of-file :stream input-buffer)
       eof-value))
 
+(defun fast-peek-byte (input-buffer &optional peek-type (eof-error-p t) eof-value)
+  "This is like `peek-byte' only for fast-io input-buffers."
+  (declare (type input-buffer input-buffer))
+  (loop :for octet = (fast-read-byte input-buffer eof-error-p :eof)
+     :for new-pos :from (input-buffer-pos input-buffer)
+     :until (cond ((eq octet :eof)
+                   (return eof-value))
+                  ((null peek-type))
+                  ((eq peek-type 't)
+                   (plusp octet))
+                  ((= octet peek-type)))
+     :finally (setf (buffer-position input-buffer) new-pos)
+       (return octet)))
+
 (defun fast-write-sequence (sequence output-buffer &optional (start 0) end)
   (if (streamp (output-buffer-output output-buffer))
       (progn


### PR DESCRIPTION
Add fast-peek-byte. I was reluctant to only use aref as this will be a problem when reading from stream. Using fast-read-byte instead. The behaviour is the same as in flexi-streams. 

If peek-type is NIL -> peek until next byte.
if peek-type is 't    -> peek until non 0 byte.
if peek-type is VALUE -> peek until VALUE byte is found.

Other values are self explanatory.

PR depends on #23 