### PR TITLE
Improve portability and fix compilation on CLISP

### DIFF
--- a/src/gray.lisp
+++ b/src/gray.lisp
@@ -24,10 +24,6 @@
     (with-slots (buffer) self
       (setf buffer (make-output-buffer :output stream)))))
 
-(defmethod output-stream-p ((stream fast-output-stream))
-  (with-slots (buffer) stream
-    (and (typep buffer 'output-buffer))))
-
 (defmethod stream-element-type ((stream fast-output-stream))
   "Return the underlying array element-type.
    Should always return '(unsigned-byte 8)."
@@ -65,10 +61,6 @@
   (call-next-method)
   (with-slots (buffer) self
     (setf buffer (make-input-buffer :vector vector :stream stream))))
-
-(defmethod input-stream-p ((stream fast-input-stream))
-  (with-slots (buffer) stream
-    (and (typep buffer 'input-buffer))))
 
 (defmethod stream-element-type ((stream fast-input-stream))
   "Return element-type of the underlying vector or stream.


### PR DESCRIPTION
On some implementations that support gray streams, such as CLISP, `input-stream-p` and `output-stream-p` are not generic functions, which makes the following code not compiled:

```lisp
(defmethod input-stream-p ((stream fast-input-stream))
  (with-slots (buffer) stream
    (and (typep buffer 'input-buffer))))

(defmethod output-stream-p ((stream fast-output-stream))
  (with-slots (buffer) stream
    (and (typep buffer 'output-buffer))))
```

Indeed, `input-stream-p` and `output-stream-p` return `t` for any instance of `fundamental-input-stream` and `fundamental-output-stream`, so the above 2 methods are not required by other implementations where they are generic functions though.